### PR TITLE
make random-bit faster on ff

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
-var randomBool = require('random-boolean');
 
 module.exports = function () {
-	return randomBool() ? 1 : 0;
+	return Math.round(Math.random());
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "get"
   ],
   "dependencies": {
-    "random-boolean": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
How do you like this implementation? 
It runs way faster on firefox and a little bit faster on other browsers (see http://jsperf.com/random-bit).
This PR also removes the dependancy to `random-boolean`, since it's not used anymore.
